### PR TITLE
添加腾讯新闻  trimmer

### DIFF
--- a/tests/testcases.js
+++ b/tests/testcases.js
@@ -8,4 +8,6 @@ module.exports = {
   "https://ishare.iclient.ifeng.com/shareNews?forward=1&aid=cmpp_030010060147781&ch=SYLB10_TOP&aman=cdM3cbLeb6V3f5gce2k8a0B5c4Sea1gb1bvece80b8": "https://news.ifeng.com/a/20181106/60147781_0.shtml",
   "https://ishare.iclient.ifeng.com/xvotr/news/shareNews?fromType=vampire&forward=1&aid=sub_85871982&ch=CJ33NEW_DOWN&token=_MGZzMmYlJmNzYWNjVmM4EGM1MGNlFWMiFjYlNWZwIGO&aman=cdx3cbceb6j3f5hce2E8a0e5c48ea1Gb1bLeceR0b8": "https://wemedia.ifeng.com/85871982/wemedia.shtml",
   "http://facebook.com.cn": "http://facebook.com.cn/",
+  "https://new.qq.com/cmsn/20181201/20181201001095.html": "https://new.qq.com/omn/20181201001095",
+  "https://view.inews.qq.com/a/20181201001095?uid=#": "https://new.qq.com/omn/20181201001095"
 };

--- a/trimmers/sites/new.qq.com.site.js
+++ b/trimmers/sites/new.qq.com.site.js
@@ -1,0 +1,19 @@
+
+const { removeAllQueries, removeHash, useHttps } = require('../tools');
+const { getPathname } = require('../utils');
+const { URL } = require('url');
+
+async function tencentNewsUrlTrimmer(url) {
+  removeAllQueries(url);
+  removeHash(url);
+  useHttps(url);
+  const pathname = getPathname(url);
+
+  lastPath = pathname[pathname.length - 1].replace('.html', '')
+  return new URL(`https://new.qq.com/omn/${lastPath}`)
+}
+
+module.exports = {
+  trimmer: tencentNewsUrlTrimmer,
+  domains: ['new.qq.com'],
+};

--- a/trimmers/sites/view.inews.qq.com.site.js
+++ b/trimmers/sites/view.inews.qq.com.site.js
@@ -1,0 +1,19 @@
+
+const { removeAllQueries, removeHash, useHttps } = require('../tools');
+const { getPathname } = require('../utils');
+const { URL } = require('url');
+
+async function mobileTencentNewsUrlTrimmer(url) {
+  removeAllQueries(url);
+  removeHash(url);
+  useHttps(url);
+  const pathname = getPathname(url);
+
+  lastPath = pathname[pathname.length - 1]
+  return new URL(`https://new.qq.com/omn/${lastPath}`)
+}
+
+module.exports = {
+  trimmer: mobileTencentNewsUrlTrimmer,
+  domains: ['view.inews.qq.com'],
+};


### PR DESCRIPTION
腾讯新闻主要有移动端和 PC 端，PC 端 URL 格式为 `https://new.qq.com/cmsn/20181201/20181201001095.html`，移动端为 `https://view.inews.qq.com/a/20181201001095?uid=#`，query paramaters 无意义，且都支持 HTTPS 访问，PC 端 URL 中间的 `cmsn` 暂时不知道什么意义，取 URL 最后一个 path 追加到 `https://new.qq.com/omn/` 后都可以正常访问